### PR TITLE
Fix appearance of buttons/inputs on iOS

### DIFF
--- a/components/button.js
+++ b/components/button.js
@@ -17,6 +17,7 @@ export default props => (
         text-transform: capitalize;
         max-height: 27px;
         line-height: 27px;
+        -webkit-appearance: none;
       }
       input:hover {
         box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.2),

--- a/pages/index.js
+++ b/pages/index.js
@@ -77,6 +77,7 @@ export default class MailTo extends React.Component {
             height: 24px;
             width: 100%;
             transition: border 0.3s;
+            -webkit-appearance: none;
           }
           .param-input:focus {
             transition: border 1s;


### PR DESCRIPTION
Before, on iPhone/iPad:
![7D412661-2C89-4E4F-9C11-BC6B1BDFE862](https://user-images.githubusercontent.com/5074763/59626412-d07b8580-9109-11e9-9752-28a455c1983c.png)

After: normal :)